### PR TITLE
Added worship app to tooling

### DIFF
--- a/src/buildForms.js
+++ b/src/buildForms.js
@@ -45,8 +45,6 @@ const projects = [
   },
   {
     name: "app-worship-decisions-database",
-    fileGraph:
-    "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer",
   }
 ];
 

--- a/src/buildForms.js
+++ b/src/buildForms.js
@@ -43,6 +43,11 @@ const projects = [
     fileGraph:
       "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer",
   },
+  {
+    name: "app-worship-decisions-database",
+    fileGraph:
+    "http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer",
+  }
 ];
 
 clearDistFolder();


### PR DESCRIPTION
Added `app-worship-decisions-database` to tooling.
Added with fileGraph: `"http://mu.semte.ch/graphs/access-for-role/PubliekeBesluitendatabank-BesluitendatabankLezer"`
which is the same as `app-public-decisions-database`