### PR TITLE
[Toezicht module] Adjust besluit handhaven form

### DIFF
--- a/formSkeleton/forms/Besluit-handhaven-na-ontvangst-schorsingsbesluit/form.ttl
+++ b/formSkeleton/forms/Besluit-handhaven-na-ontvangst-schorsingsbesluit/form.ttl
@@ -1,10 +1,13 @@
 
 
-########### Besluit-handhaven - erediensten (bestuur & centraal bestuur) ###########
+########### Besluit handhaven na ontvangst schorsingsbesluit - erediensten (bestuur & centraal bestuur) ###########
 
 fieldGroups:90fde57d-8b72-4e4e-b7f2-d04f4e12cf8b a form:FieldGroup ;
     mu:uuid "90fde57d-8b72-4e4e-b7f2-d04f4e12cf8b" ; 
-    form:hasField 
+    form:hasField
+                      ###Alert (CUSTOM)###
+                      fields:2ab610ad-871b-443e-9b79-3723390ba0c0,
+
                       ###Datum-zitting/besluit###
                       fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
 
@@ -32,7 +35,7 @@ fields:ed2e8efd-229f-420e-bb7a-0e01575359eb a form:ConditionalFieldGroup ;
         form:grouping form:Bag ;
         sh:path rdf:type ;
         form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
-        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946>
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946> 
       ] ;
     form:hasFieldGroup fieldGroups:90fde57d-8b72-4e4e-b7f2-d04f4e12cf8b .
 

--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -887,6 +887,17 @@ fields:1b0b0d89-cb84-45d9-ba07-3a067df84ccc a form:Field ;
 ##########################################################
 
 ##########################################################
+# Alert for Besluit handhaven na ontvangst schorsingsbesluit
+##########################################################
+fields:2ab610ad-871b-443e-9b79-3723390ba0c0 a form:Field;
+    mu:uuid "2ab610ad-871b-443e-9b79-3723390ba0c0" ;
+    sh:name "Met dit formulier kan je een besluit van het bestuur handhaven, na ontvangst van het schorsingsbesluit van de provinciegouverneur of de toezichthoudende gemeente of provincie.";
+    sh:order 101;
+    form:options """{ "skin": "warning", "icon": "alert-triangle", "size": "small", "closable": false }""";
+    form:displayType displayTypes:alert ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
 # Custom Fields for LEKP
 ##########################################################
 


### PR DESCRIPTION
# Description
DL-5180

This PR is about adjusting the form name for besluit handhaven and adding a new alert field.

- The name of the form is now changed to "Besluit handhaven na ontvangst schorsingsbesluit". (This has no effect on the form name itself, it's just to be consistent with the label change.
- Adding a new custom field with a `DisplayTypes:alert` in `input-fields.ttl` where it shows the following alert message -> “Met dit formulier kan je een besluit van het bestuur handhaven, na ontvangst van het schorsingsbesluit van de provinciegouverneur of de toezichthoudende gemeente of provincie.“
- Adding this new custom alert to the "Besluit handhaven na ontvangst schorsingsbesluit" form.


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Checkout frontend-loket branch `chore/ember-submission-form-fields-2.11.0`
2. Start `app-digitaal-loket` the stack on branch `feature/adjust-besluit-handhaven-form`  + frontend, migrations should run.
3. Log as a worship-service. 
4. Select Toezicht module and create a new submission with the dossier type of 'Besluit handhaven na ontvangst schorsingsbesluit'.
5. It should create the submission.

# What to check

- It should create a submission without errors.
- Existing submissions should have the new label.

# Links to other PR's

- https://github.com/lblod/app-digitaal-loket/pull/428
- https://github.com/lblod/frontend-loket/pull/321

# Notes

**ember-submission-form-fields needs to be updated in the frontend to v2.11.0**
