### PR TITLE
Adjusting form "Besluit-over-budget(wijziging)-eredienstbestuur"

### DIFF
--- a/formSkeleton/forms/Besluit-over-budget(wijziging)-eredienstbestuur/form.ttl
+++ b/formSkeleton/forms/Besluit-over-budget(wijziging)-eredienstbestuur/form.ttl
@@ -1,34 +1,26 @@
-
-
 ###########Besluit-over-budget(wijziging)-eredienstbestuur###########
 
 fieldGroups:09fd371f-2afe-4b14-81a9-e780876de077 a form:FieldGroup ;
     mu:uuid "09fd371f-2afe-4b14-81a9-e780876de077" ; 
     form:hasField 
 
-                      ###Eredienst selector###
+                      ###Betreffend-bestuur-van-de-eredienst-(eredienst-selector)###
                       fields:00a7bce6-2925-4794-93cb-ebd571b28831,
-
-                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
-                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
-
-                      ###Rapportjaar###
-                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
-
-                      ###Datum-zitting/besluit###
-                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
-
-                      ###Datum-zitting/besluit###
-                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
-
-                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
-                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
-
-                      ###Rapportjaar###
-                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
 
                       ###Welk-beslissingsorgaan-nam-het-besluit?###
                       fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Gaat-het-over-het-origineel-document-of-over-een-wijziging?###
+                      fields:a8f6a6cb-dbb8-488c-878d-05603791a9eb,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Inhoud-besluit###
+                      fields:ecc2bbf1-c76d-4237-9b7b-a4c42b2b1e29,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
 
                       ###Links-naar-documenten###
                       fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,

--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -100,8 +100,26 @@ fields:ea141dfa-80ff-4958-9493-c0cf6724cbf6 a form:Field ;
     form:displayType displayTypes:conceptSchemeSelector ;
     sh:group fields:aDynamicPropertyGroup .
 
-
-    
+fields:ecc2bbf1-c76d-4237-9b7b-a4c42b2b1e29 a form:Field;
+    mu:uuid "ecc2bbf1-c76d-4237-9b7b-a4c42b2b1e29" ;
+    sh:name "Inhoud besluit" ;
+    sh:order 2102 ;
+    sh:path rdf:type ;
+    form:validations
+      [ a form:RequiredConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup .
 
 fields:e578e3ff-240b-421b-a32c-f411489c3806 a form:Field ;
     mu:uuid "e578e3ff-240b-421b-a32c-f411489c3806" ;


### PR DESCRIPTION
# Description

DL-4736

This PR adjusts the following form "Besluit over budget wijziging" and also adds a new input field : 

- Adds a new input field named "Inhoud Besluit" as conceptSchemeSelector with the codelist `http://lblod.data.gift/concept-schemes/7856206c-dfda-4163-8bd3-f465c794eced` 

This codelist is giving three options to choose from : Akteneming, Aanpassingsbesluit and Goedkeuringsbesluit

**Note : This PR needs to be merged with the form adjustement from "Links to other PR's" Section**

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- enrich-submission
- mu-migrations

# How to test 

The forms are normally already created as semantic forms and migration in the following PR from the PR list.
For further instructions on how to test you can refer to these PRs

# What to check

- Any unexpected behavior from the form

# Links to other PR's

- Loket
- Meldingsplichtige-api
- Toezicht-abb
- Worship decisions
- Public decisions
- Manage submissions form tooling
- https://github.com/lblod/enrich-submission-service/pull/15

# Notes

N/A 