### PR TITLE
Adding new forms `Niet-bindend advies op oprichting` & `Niet-bindend advies op statuten`

### DIFF
--- a/formSkeleton/forms/Niet-bindend-advies-op-oprichting/form.ttl
+++ b/formSkeleton/forms/Niet-bindend-advies-op-oprichting/form.ttl
@@ -1,0 +1,35 @@
+###########Niet-bindend-advies-op-oprichting###########
+
+fieldGroups:48e48b72-b8d2-49f8-a0e1-7039882f3f12 a form:FieldGroup ;
+    mu:uuid "48e48b72-b8d2-49f8-a0e1-7039882f3f12" ; 
+    form:hasField 
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:e4438ae3-3979-4929-9c99-8e16b1fd49e0.
+
+fields:e4438ae3-3979-4929-9c99-8e16b1fd49e0 a form:ConditionalFieldGroup ;
+    mu:uuid "e4438ae3-3979-4929-9c99-8e16b1fd49e0";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/a2836d2f-1fee-4549-bd85-b9c13698b757>
+      ] ;
+    form:hasFieldGroup fieldGroups:48e48b72-b8d2-49f8-a0e1-7039882f3f12 .

--- a/formSkeleton/forms/Niet-bindend-advies-op-statuten/form.ttl
+++ b/formSkeleton/forms/Niet-bindend-advies-op-statuten/form.ttl
@@ -1,0 +1,35 @@
+###########Niet-bindend-advies-op-statuten###########
+
+fieldGroups:92510567-3ab3-4d18-a04b-98667a7883a9 a form:FieldGroup ;
+    mu:uuid "92510567-3ab3-4d18-a04b-98667a7883a9" ; 
+    form:hasField 
+                      ###Naam-betreffend-bedrijf/bestuur###
+                      fields:78bfbd91-0778-4573-a52d-4c53b3c512eb,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+                      
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:06b445f5-afe8-421e-be1f-cb2f9216c1e6.
+
+fields:06b445f5-afe8-421e-be1f-cb2f9216c1e6 a form:ConditionalFieldGroup ;
+    mu:uuid "06b445f5-afe8-421e-be1f-cb2f9216c1e6";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/afdb7387-da47-4dc4-bbbe-e86ea5c3df28>
+      ] ;
+    form:hasFieldGroup fieldGroups:92510567-3ab3-4d18-a04b-98667a7883a9 .


### PR DESCRIPTION
# Description

DL-5519

This PR adds two new forms `Niet-bindend advies op oprichting` & `Niet-bindend advies op statuten`

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- enrich-submission
- mu-migrations

# How to test 

1. Generate dist file and copy the forms to consuming apps
2. Make sure the following migration has run in Loket 

```sparql
INSERT DATA {
  GRAPH <http://mu.semte.ch/graphs/public> {
    <https://data.vlaanderen.be/id/concept/BesluitType/a2836d2f-1fee-4549-bd85-b9c13698b757>
      a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class> ;
      <http://mu.semte.ch/vocabularies/core/uuid> "a2836d2f-1fee-4549-bd85-b9c13698b757" ;
      <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
      <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;

      <http://lblod.data.gift/vocabularies/besluit/decidableBy> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/b156b67f-c5f4-4584-9b30-4c090be02fdc>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> ;
    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
            <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
            <http://www.w3.org/2004/02/skos/core#definition> "Niet-bindend advies op oprichting." ;
            <http://www.w3.org/2004/02/skos/core#prefLabel> "Niet-bindend advies op oprichting"@nl.
  }
}

;

INSERT DATA {
  GRAPH <http://mu.semte.ch/graphs/public> {
    <https://data.vlaanderen.be/id/concept/BesluitType/afdb7387-da47-4dc4-bbbe-e86ea5c3df28>
      a <http://www.w3.org/2004/02/skos/core#Concept>, <http://www.w3.org/2000/01/rdf-schema#Class> ;
      <http://mu.semte.ch/vocabularies/core/uuid> "afdb7387-da47-4dc4-bbbe-e86ea5c3df28" ;
      <http://www.w3.org/2004/02/skos/core#inScheme> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;
      <http://www.w3.org/2004/02/skos/core#topConceptOf> <https://data.vlaanderen.be/id/conceptscheme/BesluitType> ;

      <http://lblod.data.gift/vocabularies/besluit/decidableBy> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/b156b67f-c5f4-4584-9b30-4c090be02fdc>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d>,
      <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> ;
    <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
            <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
            <http://www.w3.org/2004/02/skos/core#definition> "Niet-bindend advies op statuten." ;
            <http://www.w3.org/2004/02/skos/core#prefLabel> "Niet-bindend advies op statuten"@nl.
  }
}
```

3. Log as Gemente or Dienstverlenende vereniging or Opdrachthoudende vereniging or Projectvereniging or OCMW or OCMW-vereniging

**form Niet-bindend advies op oprichting**

![Screenshot 2023-12-19 at 13-45-12 Loket voor lokale besturen](https://github.com/lblod/manage-submission-form-tooling/assets/38471754/d97a8ca4-0061-48f2-a3f3-8bb398544ae2)


**form Niet-bindend advies op statuten**

![Screenshot 2023-12-19 at 13-44-57 Loket voor lokale besturen](https://github.com/lblod/manage-submission-form-tooling/assets/38471754/93f1f13d-fe27-4992-932f-b4e54f74b40b)

4. Save the form, it should be saved without errors.
5. Send the form, it should be consumed by app-toezicht-abb and not by app-public-decisions-database.
a. To consume the form you can follow the docs @ https://github.com/lblod/app-toezicht-abb#trigger-import-export-flow-from-app-digitaal-loket
 
# What to check

- Typos, and form structure  

# Links to other PR's

- N/A

# Notes

- drc restart migrations resource cache enrich-submission