### PR TITLE
Adjusting LEKP forms "Collectieve renovatie" / "Fietspaden"

### DIFF
--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -1085,7 +1085,7 @@ fields:a95f2851-c371-402e-aed4-f037e2769d85 a form:Field ;
 #### Datum Collectieve Renovatie ####
 fields:7e3d3dcf-f80b-4364-9e4c-dc6fc1602232 a form:Field ;
     mu:uuid "7e3d3dcf-f80b-4364-9e4c-dc6fc1602232";
-    sh:name "Datum Collectieve renovatie (na realisatie)" ;
+    sh:name "Datum realisatie collectieve renovatie" ;
     sh:order 106 ;
     sh:path lblodBesluit:LEKPCollectieveRenovatieDate ;
     form:options """{}""" ;
@@ -1197,7 +1197,7 @@ fields:f70a9c35-a58f-4943-bdfc-7b9a761ed04c a form:Field ;
 fields:d0f11e8a-8a57-4309-91ff-e92e40d27525 a form:Field ;
     mu:uuid "d0f11e8a-8a57-4309-91ff-e92e40d27525" ;
     sh:name "Nieuw aangelegde fietsinfrastructuur op eigen grondgebied." ;
-    form:help """ Maak een optelsom van het aantal meter niew aangelegde of structureel verbeterde fietsinfrastructuur. Een tweerichtingsfietspad dat zich aan één kant van een weg bevindt, wordt in de LEKP-doelstelling meegeteld als één lengte in afstand. Noteer hiervan de lengte van A naar B (dus niet dubbel). Een fietspad dat aan beide zijden van de straat is aangelegd, kan in de twee richtingen als eenrichtingsfietspad worden ingegeven, van A naar B en van B naar A. """ ;
+    form:help """ Maak een optelsom van het aantal meter niew aangelegde of structureel verbeterde fietsinfrastructuur. Een tweerichtingsfietspad aan één zijde van de weg telt als één afstand in de LEKP-doelstelling, waarbij de lengte van A naar B wordt genoteerd. Bij een fietspad aan beide zijden kan het als eenrichtingsfietspad gelden in twee richtingen: van A naar B en van B naar A. """ ;
     sh:order 102 ;
     form:options """{ "level": "6", "skin": "6"}""" ;
     form:displayType displayTypes:heading ;

--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -1085,7 +1085,7 @@ fields:a95f2851-c371-402e-aed4-f037e2769d85 a form:Field ;
 #### Datum Collectieve Renovatie ####
 fields:7e3d3dcf-f80b-4364-9e4c-dc6fc1602232 a form:Field ;
     mu:uuid "7e3d3dcf-f80b-4364-9e4c-dc6fc1602232";
-    sh:name "Datum Collectieve rennovatie (na realisatie)" ;
+    sh:name "Datum Collectieve renovatie (na realisatie)" ;
     sh:order 106 ;
     sh:path lblodBesluit:LEKPCollectieveRenovatieDate ;
     form:options """{}""" ;

--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -1085,7 +1085,7 @@ fields:a95f2851-c371-402e-aed4-f037e2769d85 a form:Field ;
 #### Datum Collectieve Renovatie ####
 fields:7e3d3dcf-f80b-4364-9e4c-dc6fc1602232 a form:Field ;
     mu:uuid "7e3d3dcf-f80b-4364-9e4c-dc6fc1602232";
-    sh:name "Datum Beëindigen Collectieve Renovatie" ;
+    sh:name "Datum Collectieve rennovatie (na realisatie)" ;
     sh:order 106 ;
     sh:path lblodBesluit:LEKPCollectieveRenovatieDate ;
     form:options """{}""" ;
@@ -1104,7 +1104,7 @@ fields:7e3d3dcf-f80b-4364-9e4c-dc6fc1602232 a form:Field ;
 #### Hoeveel wooneenheden telde deze collectieve renovatie ? ####
 fields:e2006e32-b2fc-400b-92a1-231ff0689925 a form:Field ;
     mu:uuid "e2006e32-b2fc-400b-92a1-231ff0689925" ;
-    sh:name "Hoeveel wooneenheden telde deze collectieve renovatie ?" ;
+    sh:name "Hoeveel wooneenheden telde deze collectieve renovatie?" ;
     sh:order 107 ;
     sh:path lblodBesluit:LEKPTotalHousingUnits ;
     form:validations 
@@ -1197,7 +1197,7 @@ fields:f70a9c35-a58f-4943-bdfc-7b9a761ed04c a form:Field ;
 fields:d0f11e8a-8a57-4309-91ff-e92e40d27525 a form:Field ;
     mu:uuid "d0f11e8a-8a57-4309-91ff-e92e40d27525" ;
     sh:name "Nieuw aangelegde fietsinfrastructuur op eigen grondgebied." ;
-    form:help """ Maak een optelsom van het aantal meter niew aangelegde of structureel verbeterde fietsinfrastructuur. Een tweerichtingsfietspad (aan één kant van een weg), wordt in de LEKP-doelstelling meegeteld als een lengte in afstand. """ ;
+    form:help """ Maak een optelsom van het aantal meter niew aangelegde of structureel verbeterde fietsinfrastructuur. Een tweerichtingsfietspad dat zich aan één kant van een weg bevindt, wordt in de LEKP-doelstelling meegeteld als één lengte in afstand. Noteer hiervan de lengte van A naar B (dus niet dubbel). Een fietspad dat aan beide zijden van de straat is aangelegd, kan in de twee richtingen als eenrichtingsfietspad worden ingegeven, van A naar B en van B naar A. """ ;
     sh:order 102 ;
     form:options """{ "level": "6", "skin": "6"}""" ;
     form:displayType displayTypes:heading ;
@@ -1211,6 +1211,12 @@ fields:6a4f780a-de31-476c-bd7e-f24080339b31 a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2021 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2021 
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1229,6 +1235,12 @@ fields:8b6bc220-a980-4d1e-b7b3-5a6324d1ad4f a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewOneWayBicycleInfrastructureFor2021 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
             sh:order 106;
@@ -1245,6 +1257,12 @@ fields:f79d9036-5734-463d-826b-d093a6f4e0c5 a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2021 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2021 
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1264,6 +1282,12 @@ fields:9ec715da-fb12-4fda-bec4-188e4ea6783c a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2021 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
             sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2021 ;
@@ -1280,6 +1304,12 @@ fields:bfa729b9-2a4e-4fe6-b8cb-e6de01ffacf6 a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2022 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2022 
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1298,6 +1328,12 @@ fields:10bfc794-041a-485f-bfe2-2aa82acee56f a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewOneWayBicycleInfrastructureFor2022 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
             sh:order 114;
@@ -1314,6 +1350,12 @@ fields:5592b583-d9b4-45df-8b2c-d153a6d712db a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2022 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2022 
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1333,9 +1375,15 @@ fields:9d195161-d9c2-46a9-ad50-f83095aca568 a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2022 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
-sh:order 118;
+            sh:order 118;
             sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2022 ;
             sh:resultMessage "Geen negatieve waarden"
         ] ;
@@ -1349,6 +1397,12 @@ fields:857f1d9e-ecbb-4461-819a-7e15aee2e82d a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2023 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2023 
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1367,6 +1421,12 @@ fields:2a47484a-3e09-4c75-9c9f-04956145ae02 a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewOneWayBicycleInfrastructureFor2023 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
             sh:order 122;
@@ -1383,6 +1443,12 @@ fields:7d8f0e21-7e3d-4f39-88e4-195175a63d65 a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2023 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2023 
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1402,9 +1468,15 @@ fields:00ccc3c2-7e4c-43b5-bf3b-f62542856745 a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2023 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
-sh:order 126;
+            sh:order 126;
             sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2023 ;
             sh:resultMessage "Geen negatieve waarden"
         ] ;
@@ -1418,6 +1490,12 @@ fields:788a6000-097d-4ea7-9a3b-e64ce78e266c a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2024 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedOneWayBicycleInfrastructureFor2024 
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1436,6 +1514,12 @@ fields:5a554529-0c7e-43f2-b29e-ddfa39df9b88 a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewOneWayBicycleInfrastructureFor2024 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
             sh:order 130;
@@ -1452,6 +1536,12 @@ fields:c1bce5db-aeee-4246-acd5-764ed4be3d1b a form:Field ;
     sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2024 ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
+        [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForRenovatedBiDirectionalWayBicycleInfrastructureFor2024
+        ],
         [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
@@ -1471,9 +1561,15 @@ fields:9e86bf79-170d-4136-9aa9-9db6df27883c a form:Field ;
     form:displayType displayTypes:numericalInput ;
     form:validations 
         [
+            a form:RequiredConstraint ;
+            form:grouping form:Bag ;
+            sh:resultMessage "Dit veld is verplicht." ;
+            sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2024 
+        ],
+        [
             a form:PositiveNumber;
             form:grouping form:MatchEvery;
-sh:order 134;
+            sh:order 134;
             sh:path lblodBesluit:LEKPTotalKmForNewBiDirectionalWayBicycleInfrastructureFor2024 ;
             sh:resultMessage "Geen negatieve waarden"
         ] ;
@@ -1488,10 +1584,10 @@ fields:edfcdaa6-456a-48f2-b2ba-39a460be1a28 a form:Field ;
     form:displayType displayTypes:heading ;
     sh:group fields:aDynamicPropertyGroup .
 
-#### Van Welke andere subsidies dan het Fietsfonds of Kopenhagenfonds heb je gebruik gemaakt ? ####
+#### Van welke andere subsidies dan het Fietsfonds of Kopenhagenfonds heb je gebruik gemaakt ? ####
   fields:0e47f2d1-e8cd-4ea0-9ea8-4d1e2194769d a form:Field ;
     mu:uuid "0e47f2d1-e8cd-4ea0-9ea8-4d1e2194769d";
-    sh:name "Van Welke andere subsidies dan het Fietsfonds of Kopenhagenfonds heb je gebruik gemaakt ?" ;
+    sh:name "Van welke andere subsidies dan het Fietsfonds of Kopenhagenfonds heb je gebruik gemaakt?" ;
     sh:order 136 ;
     sh:path lblodBesluit:LEKPOtherFietsfondsSubsidy ;
     form:options """{}""" ;
@@ -1507,7 +1603,7 @@ fields:edfcdaa6-456a-48f2-b2ba-39a460be1a28 a form:Field ;
 #### Heb je hiervoor met andere overheidsinstanties, steden of gemeenten samegewerkt ? Welke ? ####
   fields:842a3ef1-138c-408a-af3d-6016cae24a2c a form:Field ;
     mu:uuid "842a3ef1-138c-408a-af3d-6016cae24a2c";
-    sh:name "Heb je hiervoor met andere overheidsinstanties, steden of gemeenten samegewerkt ? Welke ?" ;
+    sh:name "Heb je hiervoor met andere overheidsinstanties, steden of gemeenten samegewerkt? Welke?" ;
     sh:order 137 ;
     sh:path lblodBesluit:LEKPFietsSubsidyCollaborationWith ;
     form:options """{}""" ;

--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -1197,7 +1197,7 @@ fields:f70a9c35-a58f-4943-bdfc-7b9a761ed04c a form:Field ;
 fields:d0f11e8a-8a57-4309-91ff-e92e40d27525 a form:Field ;
     mu:uuid "d0f11e8a-8a57-4309-91ff-e92e40d27525" ;
     sh:name "Nieuw aangelegde fietsinfrastructuur op eigen grondgebied." ;
-    form:help """ Maak een optelsom van het aantal meter niew aangelegde of structureel verbeterde fietsinfrastructuur. Een tweerichtingsfietspad aan één zijde van de weg telt als één afstand in de LEKP-doelstelling, waarbij de lengte van A naar B wordt genoteerd. Bij een fietspad aan beide zijden kan het als eenrichtingsfietspad gelden in twee richtingen: van A naar B en van B naar A. """ ;
+    form:help """ Maak een optelsom van het aantal meter nieuw aangelegde of structureel verbeterde fietsinfrastructuur. Een tweerichtingsfietspad aan één zijde van de weg telt als één afstand in de LEKP-doelstelling, waarbij de lengte van A naar B wordt genoteerd. Bij een fietspad aan beide zijden kan het als eenrichtingsfietspad gelden in twee richtingen: van A naar B en van B naar A. """ ;
     sh:order 102 ;
     form:options """{ "level": "6", "skin": "6"}""" ;
     form:displayType displayTypes:heading ;
@@ -1584,7 +1584,7 @@ fields:edfcdaa6-456a-48f2-b2ba-39a460be1a28 a form:Field ;
     form:displayType displayTypes:heading ;
     sh:group fields:aDynamicPropertyGroup .
 
-#### Van welke andere subsidies dan het Fietsfonds of Kopenhagenfonds heb je gebruik gemaakt ? ####
+#### Van welke andere subsidies dan het Fietsfonds of Kopenhagenfonds heb je gebruik gemaakt? ####
   fields:0e47f2d1-e8cd-4ea0-9ea8-4d1e2194769d a form:Field ;
     mu:uuid "0e47f2d1-e8cd-4ea0-9ea8-4d1e2194769d";
     sh:name "Van welke andere subsidies dan het Fietsfonds of Kopenhagenfonds heb je gebruik gemaakt?" ;
@@ -1600,10 +1600,10 @@ fields:edfcdaa6-456a-48f2-b2ba-39a460be1a28 a form:Field ;
       sh:path lblodBesluit:LEKPOtherFietsfondsSubsidy ] ;
     sh:group fields:aDynamicPropertyGroup.
 
-#### Heb je hiervoor met andere overheidsinstanties, steden of gemeenten samegewerkt ? Welke ? ####
+#### Heb je hiervoor met andere overheidsinstanties, steden of gemeenten samengewerkt? Welke? ####
   fields:842a3ef1-138c-408a-af3d-6016cae24a2c a form:Field ;
     mu:uuid "842a3ef1-138c-408a-af3d-6016cae24a2c";
-    sh:name "Heb je hiervoor met andere overheidsinstanties, steden of gemeenten samegewerkt? Welke?" ;
+    sh:name "Heb je hiervoor met andere overheidsinstanties, steden of gemeenten samengewerkt? Welke?" ;
     sh:order 137 ;
     sh:path lblodBesluit:LEKPFietsSubsidyCollaborationWith ;
     form:options """{}""" ;


### PR DESCRIPTION
# Description

DL-5570

This PR adjusts the forms  "Collectieve renovatie" / "Fietspaden"

- Changing validation for the Fietspaden questions, these fields are now mandatory as it was possible to save the form empty. Now it's not the case and all fields needs to be completed in order to save the form. The last two questions from additional comments are still optional.
- Fixing typo issues such as spacing and uppercase in the Fietspaden form.
- Adjusting text to be now "Een tweerichtingsfietspad aan één zijde van de weg telt als één afstand in de LEKP-doelstelling, waarbij de lengte van A naar B wordt genoteerd. Bij een fietspad aan beide zijden kan het als eenrichtingsfietspad gelden in twee richtingen: van A naar B en van B naar A." instead of "Een tweerichtingsfietspad (aan één kant van een weg), wordt in de LEKP-doelstelling meegeteld als een lengte in afstand."
- Adjusting text in Collective renovatie form to be "Datum realisatie collectieve renovatie" instead of "Datum Beëindigen Collectieve Renovatie"

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- enrich-submission
- mu-migrations

# How to test 

1. Generate dist file and copy the forms to consuming apps
2. Make sure the following migration has run in Loket 
3. Log as Gemente 
4. Save the form, it should be saved without errors.
5. Send the form, it should be consumed by app-toezicht-abb and not by app-public-decisions-database.
a. To consume the form you can follow the docs @ https://github.com/lblod/app-toezicht-abb#trigger-import-export-flow-from-app-digitaal-loket
 
# What to check

- Typos, and form structure  

# Links to other PR's

- N/A

# Notes

- drc restart migrations resource cache enrich-submission