### PR TITLE
LEKP : Adjust form Klimaattafels & add new form Wijkverbeteringscontract

### DIFF
--- a/formSkeleton/forms/Advies-bij-jaarrekening-eredienstbestuur/form.ttl
+++ b/formSkeleton/forms/Advies-bij-jaarrekening-eredienstbestuur/form.ttl
@@ -1,12 +1,37 @@
 ##########################################################
-# Info Upload for "Advies-bij-jaarrekening-eredienstbestuur"
+# Advies-bij-jaarrekening-eredienstbestuur
 ##########################################################
+
+#### Info Upload ####
 fields:6f081c43-23d8-4850-b9b0-d8f9d7dc89e6 a form:Field;
     mu:uuid "6f081c43-23d8-4850-b9b0-d8f9d7dc89e6" ;
     sh:name "Voeg hier het advies aan de provinciegouverneur over de jaarrekening toe.";
     sh:order 10002;
     form:options """{ "skin": "info", "icon": "info-circle", "size": "small", "closable": false }""";
     form:displayType displayTypes:alert ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### Inhoud Besluit ####
+
+fields:073abe27-3c32-4cb7-ac0b-3974084ca229 a form:Field;
+    mu:uuid "073abe27-3c32-4cb7-ac0b-3974084ca229" ;
+    sh:name "Inhoud besluit" ;
+    sh:order 2102 ;
+    sh:path rdf:type ;
+    form:validations
+      [ a form:RequiredConstraint ; #TODO
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ],
+      [ a form:ConceptSchemeConstraint ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/4aebe5c8-899b-40a9-952f-c0e3c5de4ae9> ;
+        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
+      ] ;
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/4aebe5c8-899b-40a9-952f-c0e3c5de4ae9"}""" ;
+    form:displayType displayTypes:conceptSchemeSelector ;
     sh:group fields:aDynamicPropertyGroup .
 
 ###########Advies-bij-jaarrekening-eredienstbestuur###########
@@ -32,6 +57,9 @@ fieldGroups:91045004-2066-40f3-aac1-bf2309eb2b99 a form:FieldGroup ;
 
                       ###Rapportjaar###
                       fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+                      
+                      ###Inhoud Besluit###
+                      fields:073abe27-3c32-4cb7-ac0b-3974084ca229,
 
                       ###Links-naar-documenten###
                       fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,

--- a/formSkeleton/forms/Advies-bij-jaarrekening-eredienstbestuur/form.ttl
+++ b/formSkeleton/forms/Advies-bij-jaarrekening-eredienstbestuur/form.ttl
@@ -1,37 +1,12 @@
 ##########################################################
-# Advies-bij-jaarrekening-eredienstbestuur
+# Info Upload for "Advies-bij-jaarrekening-eredienstbestuur"
 ##########################################################
-
-#### Info Upload ####
 fields:6f081c43-23d8-4850-b9b0-d8f9d7dc89e6 a form:Field;
     mu:uuid "6f081c43-23d8-4850-b9b0-d8f9d7dc89e6" ;
     sh:name "Voeg hier het advies aan de provinciegouverneur over de jaarrekening toe.";
     sh:order 10002;
     form:options """{ "skin": "info", "icon": "info-circle", "size": "small", "closable": false }""";
     form:displayType displayTypes:alert ;
-    sh:group fields:aDynamicPropertyGroup .
-
-#### Inhoud Besluit ####
-
-fields:073abe27-3c32-4cb7-ac0b-3974084ca229 a form:Field;
-    mu:uuid "073abe27-3c32-4cb7-ac0b-3974084ca229" ;
-    sh:name "Inhoud besluit" ;
-    sh:order 2102 ;
-    sh:path rdf:type ;
-    form:validations
-      [ a form:RequiredConstraint ; #TODO
-        form:grouping form:Bag ;
-        sh:path rdf:type ;
-        sh:resultMessage "Dit veld is verplicht."@nl
-      ],
-      [ a form:ConceptSchemeConstraint ;
-        form:grouping form:Bag ;
-        sh:path rdf:type ;
-        form:conceptScheme <http://lblod.data.gift/concept-schemes/4aebe5c8-899b-40a9-952f-c0e3c5de4ae9> ;
-        sh:resultMessage "Selecteer een waarde uit de lijst."@nl
-      ] ;
-    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/4aebe5c8-899b-40a9-952f-c0e3c5de4ae9"}""" ;
-    form:displayType displayTypes:conceptSchemeSelector ;
     sh:group fields:aDynamicPropertyGroup .
 
 ###########Advies-bij-jaarrekening-eredienstbestuur###########
@@ -57,9 +32,6 @@ fieldGroups:91045004-2066-40f3-aac1-bf2309eb2b99 a form:FieldGroup ;
 
                       ###Rapportjaar###
                       fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
-                      
-                      ###Inhoud Besluit###
-                      fields:073abe27-3c32-4cb7-ac0b-3974084ca229,
 
                       ###Links-naar-documenten###
                       fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,

--- a/formSkeleton/forms/LEKP-rapport-klimaattafels/form.ttl
+++ b/formSkeleton/forms/LEKP-rapport-klimaattafels/form.ttl
@@ -25,7 +25,7 @@ fieldGroups:b1143874-884d-4ffd-8d69-97383870a42e a form:FieldGroup ;
     mu:uuid "b1143874-884d-4ffd-8d69-97383870a42e" ; 
     form:hasField 
                       ### Infolabel 
-                      fields:2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e,
+                      fields:d0644dd9-5181-49c8-9bef-bf109aabdc59,
                       
                       ### climateTable Date
                       fields:2bc38df5-dc28-4d4d-a6e1-b6d95644c8d7,

--- a/formSkeleton/forms/LEKP-rapport-klimaattafels/form.ttl
+++ b/formSkeleton/forms/LEKP-rapport-klimaattafels/form.ttl
@@ -1,3 +1,24 @@
+##########################################################
+# LEKP-rapport - Klimaattafels
+##########################################################
+
+#### Hoeveel deelnemende wooneenheden kregen een renovatietraject voorgesteld? (LEKP 2.1) ####
+fields:df50e066-b12a-4a93-be9e-7a56777cf1bd a form:Field ;
+    mu:uuid "df50e066-b12a-4a93-be9e-7a56777cf1bd" ;
+    sh:name "Hoeveel deelnemende wooneenheden kregen een renovatietraject voorgesteld? (LEKP 2.1)" ;
+        sh:order 104 ;
+    sh:path lblodBesluit:LEKPTotalHousingForRenovatingProject ;
+    form:displayType displayTypes:numericalInput ;
+    form:validations 
+        [
+            a form:PositiveNumber;
+            form:grouping form:MatchEvery;
+            sh:order 105;
+            sh:path lblodBesluit:LEKPTotalHousingForRenovatingProject ;
+            sh:resultMessage "Geen negatieve waarden"
+        ] ;
+    sh:group fields:aDynamicPropertyGroup .
+
 ###########LEKP-Rapport Klimaattafels###########
 
 fieldGroups:b1143874-884d-4ffd-8d69-97383870a42e a form:FieldGroup ;
@@ -12,8 +33,14 @@ fieldGroups:b1143874-884d-4ffd-8d69-97383870a42e a form:FieldGroup ;
                       ### Households
                       fields:28ddce67-6aaf-4a3b-8953-63eeb7178d1f,
 
+                      ### Hoeveel deelnemende wooneenheden kregen een renovatietraject voorgesteld? (LEKP 2.1)
+                      fields:df50e066-b12a-4a93-be9e-7a56777cf1bd,
+
                       ### Links
                       fields:df63b483-f2ee-4274-a7d0-0cfc916d22ce,
+                      
+                      ### Bestanden
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a,
 
                       ### RemoteDataObject/url ###
                       fields:355fe001-cdca-48cc-8a6e-88b3aab09874,

--- a/formSkeleton/forms/LEKP-rapport-wijkverbeteringscontract/form.ttl
+++ b/formSkeleton/forms/LEKP-rapport-wijkverbeteringscontract/form.ttl
@@ -1,0 +1,190 @@
+##########################################################
+# LEKP-rapport - Wijkverbeteringscontract
+##########################################################
+
+#### Infolabel ####
+fields:e22b6983-9d8f-43c7-9917-097d54879bdf a form:Field;
+    mu:uuid "e22b6983-9d8f-43c7-9917-097d54879bdf" ;
+    sh:name "Dit dossiertype heeft betrekking op het Lokaal Energie- en Klimaatpact.";
+    form:help """
+    <a href="https://lokaalklimaatpact.be/hoe-rapporteren/doelstellingen-rapporteren/loket-voor-lokale-besturen" target="_blank">Meer informatie daarover, alsook over dit formulier, kan je hier terugvinden. </a>
+    """ ;
+    sh:order 101;
+    form:options """{ "level": "6", "skin": "6"}""";
+    form:displayType displayTypes:heading ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### Naam wijkverbeteringscontract ####
+fields:b4466ad1-7965-4b41-af74-17b6f16cf866 a form:Field ;
+    mu:uuid "b4466ad1-7965-4b41-af74-17b6f16cf866";
+    sh:name "Naam wijkverbeteringscontract" ;
+    sh:order 102 ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPDistrictImprovementContractName ],
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "100" ;
+      sh:order 103;
+      sh:resultMessage "Max. karakters overschreden." ;
+      sh:path lblodBesluit:LEKPDistrictImprovementContractName ];
+    sh:path lblodBesluit:LEKPDistrictImprovementContractName ;
+    form:options """{}""" ;
+    form:displayType displayTypes:defaultInput ;
+    sh:group fields:aDynamicPropertyGroup .
+
+### Datum lancering wijkverbeteringscontract ###
+fields:e68a1b2b-624f-4e7a-b1c6-ac1064471a1e a form:Field ;
+    mu:uuid "e68a1b2b-624f-4e7a-b1c6-ac1064471a1e";
+    sh:name "Datum lancering wijkverbeteringscontract" ;
+    sh:order 104 ;
+    sh:path lblodBesluit:LEKPDistrictImprovementContractLaunchDate ;
+    form:options """{}""" ;
+    form:displayType displayTypes:date ;
+    form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPDistrictImprovementContractLaunchDate ],
+    [ a form:ValidDate ;
+      form:grouping form:MatchEvery ;
+      sh:resultMessage "Geef een geldige datum op." ;
+      sh:path lblodBesluit:LEKPDistrictImprovementContractLaunchDate ] ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### 1. Welke nieuwe samenwerkingsvormen/partnerschappen werden tot stand gebracht? ####
+fields:258bb1a4-00fb-4a9d-a5a4-ac40884ca1a0 a form:Field ;
+    mu:uuid "258bb1a4-00fb-4a9d-a5a4-ac40884ca1a0";
+    sh:name "1. Welke nieuwe samenwerkingsvormen/partnerschappen werden tot stand gebracht?" ;
+    sh:order 105 ;
+    form:validations
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "100" ;
+      sh:order 106;
+      sh:resultMessage "Max. karakters overschreden." ;
+      sh:path lblodBesluit:LEKPNewCollaborations ];
+    sh:path lblodBesluit:LEKPNewCollaborations ;
+    form:options """{}""" ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### 2. Welke wijk werd betrokken? ####
+fields:2a2020f4-96e5-4824-9720-eae707ba16bc a form:Field ;
+    mu:uuid "2a2020f4-96e5-4824-9720-eae707ba16bc";
+    sh:name "2. Welke wijk werd betrokken?" ;
+    sh:order 107 ;
+    form:validations
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "100" ;
+      sh:order 108;
+      sh:resultMessage "Max. karakters overschreden." ;
+      sh:path lblodBesluit:LEKPInvolvedDistrict ];
+    sh:path lblodBesluit:LEKPInvolvedDistrict ;
+    form:options """{}""" ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### 3. Licht de collectieve (energiebesparende) renovatiemaatregelen toe ####
+fields:bd7e8379-1cd1-402e-9571-53942deeacdf a form:Field ;
+    mu:uuid "bd7e8379-1cd1-402e-9571-53942deeacdf";
+    sh:name "3. Licht de collectieve (energiebesparende) renovatiemaatregelen toe" ;
+    sh:order 109 ;
+    form:validations
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "100" ;
+      sh:order 110;
+      sh:resultMessage "Max. karakters overschreden." ;
+      sh:path lblodBesluit:LEKPRenovationsMeasures ];
+    sh:path lblodBesluit:LEKPRenovationsMeasures ;
+    form:options """{}""" ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### 4. Hoe werd ingezet op sociale diversiteit? ####
+fields:b46781f5-b576-408e-8d01-931622131fef a form:Field ;
+    mu:uuid "b46781f5-b576-408e-8d01-931622131fef";
+    sh:name "4. Hoe werd ingezet op sociale diversiteit?" ;
+    sh:order 111 ;
+    form:validations
+    [ a form:MaxLength ;
+      form:grouping form:MatchEvery ;
+      form:max "100" ;
+      sh:order 112;
+      sh:resultMessage "Max. karakters overschreden." ;
+      sh:path lblodBesluit:LEKPSocialDiversity ];
+    sh:path lblodBesluit:LEKPSocialDiversity ;
+    form:options """{}""" ;
+    form:displayType displayTypes:textArea ;
+    sh:group fields:aDynamicPropertyGroup .
+
+#### Bestanden - Custom helper text Voeg het wijkverbeteringscontract toe ####
+fields:8d6c1414-948e-46d9-8b54-749c21870955 a form:Field ;
+    mu:uuid "8d6c1414-948e-46d9-8b54-749c21870955" ;
+    sh:name "Bestanden" ;
+    sh:order 10001 ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+    form:displayType displayTypes:files; # consider this v1.0
+    form:help """Voeg het wijkverbeteringscontract toe.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+###########LEKP-rapport - Wijkverbeteringscontract###########
+
+fieldGroups:f6528069-4606-432a-97b4-52a319870ea9 a form:FieldGroup ;
+    mu:uuid "f6528069-4606-432a-97b4-52a319870ea9" ; 
+    form:hasField 
+                      ### Infolabel 
+                      fields:e22b6983-9d8f-43c7-9917-097d54879bdf,
+                      
+                      ### Naam wijkverbeteringscontract
+                      fields:b4466ad1-7965-4b41-af74-17b6f16cf866,
+
+                      ### Datum lancering wijkverbeteringscontract
+                      fields:e68a1b2b-624f-4e7a-b1c6-ac1064471a1e,
+
+                      ### Welke nieuwe samenwerkingsvormen/partnerschappen werden tot stand gebracht?
+                      fields:258bb1a4-00fb-4a9d-a5a4-ac40884ca1a0,
+
+                      ### Welke wijk werd betrokken?
+                      fields:2a2020f4-96e5-4824-9720-eae707ba16bc,
+
+                      ### Licht de collectieve (energiebesparende) renovatiemaatregelen toe
+                      fields:bd7e8379-1cd1-402e-9571-53942deeacdf,
+
+                      ### Hoe werd ingezet op sociale diversiteit?
+                      fields:b46781f5-b576-408e-8d01-931622131fef,
+
+                      ### Link (custom)
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ### Bestanden - Voeg het wijkverbeteringscontract toe (Required)
+                      fields:8d6c1414-948e-46d9-8b54-749c21870955,
+
+                      ### Type RemoteDataObject or FileDataObject
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:634a1241-301e-4de6-a0d3-1197821922db.
+
+fields:634a1241-301e-4de6-a0d3-1197821922db a form:ConditionalFieldGroup ;
+    mu:uuid "634a1241-301e-4de6-a0d3-1197821922db";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/094cef43-055a-4deb-8692-bc0a91a8a2b6>
+      ] ;
+    form:hasFieldGroup fieldGroups:f6528069-4606-432a-97b4-52a319870ea9 .

--- a/formSkeleton/forms/LEKP-rapport-wijkverbeteringscontract/form.ttl
+++ b/formSkeleton/forms/LEKP-rapport-wijkverbeteringscontract/form.ttl
@@ -60,6 +60,10 @@ fields:258bb1a4-00fb-4a9d-a5a4-ac40884ca1a0 a form:Field ;
     sh:name "1. Welke nieuwe samenwerkingsvormen/partnerschappen werden tot stand gebracht?" ;
     sh:order 105 ;
     form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPNewCollaborations ],
     [ a form:MaxLength ;
       form:grouping form:MatchEvery ;
       form:max "100" ;
@@ -77,6 +81,10 @@ fields:2a2020f4-96e5-4824-9720-eae707ba16bc a form:Field ;
     sh:name "2. Welke wijk werd betrokken?" ;
     sh:order 107 ;
     form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPInvolvedDistrict ],
     [ a form:MaxLength ;
       form:grouping form:MatchEvery ;
       form:max "100" ;
@@ -94,6 +102,10 @@ fields:bd7e8379-1cd1-402e-9571-53942deeacdf a form:Field ;
     sh:name "3. Licht de collectieve (energiebesparende) renovatiemaatregelen toe" ;
     sh:order 109 ;
     form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPRenovationsMeasures ],
     [ a form:MaxLength ;
       form:grouping form:MatchEvery ;
       form:max "100" ;
@@ -111,6 +123,10 @@ fields:b46781f5-b576-408e-8d01-931622131fef a form:Field ;
     sh:name "4. Hoe werd ingezet op sociale diversiteit?" ;
     sh:order 111 ;
     form:validations
+    [ a form:RequiredConstraint ;
+      form:grouping form:Bag ;
+      sh:resultMessage "Dit veld is verplicht." ;
+      sh:path lblodBesluit:LEKPSocialDiversity ],
     [ a form:MaxLength ;
       form:grouping form:MatchEvery ;
       form:max "100" ;

--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -831,18 +831,6 @@ fields:143c2d80-0a31-4a1b-bdad-a723a4aa1efe a form:Field;
 # Custom Fields for LEKP
 ##########################################################
 
-#### Infolabel ####
-fields:2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e a form:Field;
-    mu:uuid "2bb6c63d-2cb7-4e82-839f-5c1e0a4f6a5e" ;
-    sh:name "Dit dossierstype heeft betrekking tot het Lokaal Energie- en Klimaatpact.";
-    form:help """
-    <a href="https://lokaalklimaatpact.be/formulieren.html" target="_blank">Meer informatie daarover, alsook over dit formulier, kun je hier terugvinden. </a>
-    """ ;
-    sh:order 101;
-    form:options """{ "level": "6", "skin": "6"}""";
-    form:displayType displayTypes:heading ;
-    sh:group fields:aDynamicPropertyGroup .
-
 #### Custom Infolabel ####
 fields:d0644dd9-5181-49c8-9bef-bf109aabdc59 a form:Field ;
     mu:uuid "d0644dd9-5181-49c8-9bef-bf109aabdc59" ;


### PR DESCRIPTION
# Description

DL-5829
DL-5832

This PR : 
- adds a new form LEKP rapport - Wijkverbeteringscontract usable by Gemeenten (Municipality)
- Adjust existing form LEKP rapport - Klimaattafels to add a new optional field and a file download field

#### LEKP rapport - Wijkverbeteringscontract
![Screenshot 2024-04-29 at 17-10-35 Loket voor lokale besturen](https://github.com/lblod/manage-submission-form-tooling/assets/38471754/7db2a256-17db-4b1b-b08d-44c5b100e43c)

#### LEKP rapport - Klimaattafels
![Screenshot 2024-04-29 at 16-29-29 Loket voor lokale besturen](https://github.com/lblod/manage-submission-form-tooling/assets/38471754/bb23eeb4-1051-470f-a02c-f34b5a5bdf4b)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- enrich-submission
- mu-migrations

# How to test (From Loket app)

1. Generate dist file and copy the forms to consuming apps
2. Make sure the following migration has run in Loket 
3. Log as Gemeente
4. Save forms, it should be saved without errors.
5. Send the form, it should be consumed by app-toezicht-abb.
a. To consume the form you can follow the docs @ https://github.com/lblod/app-toezicht-abb#trigger-import-export-flow-from-app-digitaal-loket

# What to check

- Typos, and form structure  

# Links to other PR's

- https://github.com/lblod/app-digitaal-loket/pull/567
- https://github.com/lblod/app-meldingsplichtige-api/pull/42
- https://github.com/lblod/app-public-decisions-database/pull/26
- https://github.com/lblod/app-toezicht-abb/pull/39
- https://github.com/lblod/app-worship-decisions-database/pull/73

# Notes

- drc restart migrations resource cache enrich-submission