### PR TITLE
Add the `decisionDocuments` field to some CKB forms

### DIFF
--- a/formSkeleton/forms/Budgetten(wijzigingen)-indiening-bij-representatief-orgaan/form.ttl
+++ b/formSkeleton/forms/Budgetten(wijzigingen)-indiening-bij-representatief-orgaan/form.ttl
@@ -18,9 +18,9 @@ fields:93e4f5f9-79b8-4850-a562-8ce8fa184097 a form:Field;
     sh:order 10002;
     form:options """{ "skin": "info", "icon": "info-circle", "size": "small", "closable": false }""";
     form:displayType displayTypes:alert ;
-    sh:group fields:aDynamicPropertyGroup .  
+    sh:group fields:aDynamicPropertyGroup .
 
-###########Budgetten(wijzigingen) - Indiening bij representatief orgaan########### 
+###########Budgetten(wijzigingen) - Indiening bij representatief orgaan###########
 
 fieldGroups:aaf4f9b2-643f-474d-b1b0-24f37784e5a6 a form:FieldGroup ;
     mu:uuid "aaf4f9b2-643f-474d-b1b0-24f37784e5a6" ;
@@ -33,6 +33,9 @@ fieldGroups:aaf4f9b2-643f-474d-b1b0-24f37784e5a6 a form:FieldGroup ;
 
                       ###Rapportjaar###
                       fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Gerelateerde documenten###
+                      fields:3b05127d-d3ec-46c5-8e58-664334eed2d3,
 
                       ###Links-naar-documenten###
                       fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,

--- a/formSkeleton/forms/Budgetten(wijzigingen)-indiening-bij-toezichthoudende-gemeente-of-provincie/form.ttl
+++ b/formSkeleton/forms/Budgetten(wijzigingen)-indiening-bij-toezichthoudende-gemeente-of-provincie/form.ttl
@@ -18,7 +18,7 @@ fields:829f47a1-6d88-4c19-a119-d0baf779972c a form:Field;
     sh:order 10002;
     form:options """{ "skin": "info", "icon": "info-circle", "size": "small", "closable": false }""";
     form:displayType displayTypes:alert ;
-    sh:group fields:aDynamicPropertyGroup .  
+    sh:group fields:aDynamicPropertyGroup .
 
 ###########Budgetten(wijzigingen) - Indiening bij toezichthoudende gemeente of provincie###########
 
@@ -33,6 +33,9 @@ fieldGroups:7832d3be-7e6a-4ff8-9e47-be2654174668 a form:FieldGroup ;
 
                       ###Rapportjaar###
                       fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Gerelateerde documenten###
+                      fields:3b05127d-d3ec-46c5-8e58-664334eed2d3,
 
                       ###Links-naar-documenten###
                       fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
@@ -61,6 +64,6 @@ fields:4ae23c37-b731-408c-a999-33d0b7183a23 a form:ConditionalFieldGroup ;
         form:grouping form:Bag ;
         sh:path rdf:type ;
         form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
-        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29> 
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/ce569d3d-25ff-4ce9-a194-e77113597e29>
       ];
     form:hasFieldGroup fieldGroups:7832d3be-7e6a-4ff8-9e47-be2654174668 .

--- a/formSkeleton/forms/Gecoordineerde-inzending-meerjarenplannen/form.ttl
+++ b/formSkeleton/forms/Gecoordineerde-inzending-meerjarenplannen/form.ttl
@@ -21,6 +21,9 @@ fieldGroups:bef0fd9f-5f60-4e68-b8d7-1b515cc3ccc2 a form:FieldGroup ;
                       ###Rapportperiode###
                       fields:e578e3ff-240b-421b-a32c-f411489c3806,
 
+                      ###Gerelateerde documenten###
+                      fields:3b05127d-d3ec-46c5-8e58-664334eed2d3,
+
                       ###Links-naar-documenten###
                       fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
 
@@ -32,10 +35,10 @@ fieldGroups:bef0fd9f-5f60-4e68-b8d7-1b515cc3ccc2 a form:FieldGroup ;
 
                       ###Related decision [hidden]###
                       fields:c0f621fc-4c2c-456b-83f9-f087e64af03a,
-                      
+
                       ### RemoteDataObject/url ###
                       fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db,
-                      
+
                       ###Info Upload (CUSTOM)###
                       fields:dd66fed0-c025-44de-80bd-bec8b39f5021.
 

--- a/formSkeleton/forms/Gezamenlijke-inzending-jaarrekeningen/form.ttl
+++ b/formSkeleton/forms/Gezamenlijke-inzending-jaarrekeningen/form.ttl
@@ -7,7 +7,7 @@ fields:4ee01de8-46b2-4109-84cf-d60bebaeb10e a form:Field;
     sh:order 10002;
     form:options """{ "skin": "info", "icon": "info-circle", "size": "small", "closable": false }""";
     form:displayType displayTypes:alert ;
-    sh:group fields:aDynamicPropertyGroup .  
+    sh:group fields:aDynamicPropertyGroup .
 
 ###########Gezamenlijke-inzending-jaarrekeningen###########
 
@@ -16,6 +16,9 @@ fieldGroups:40fa78b5-4e89-47c0-99cb-a8e936a09d19 a form:FieldGroup ;
     form:hasField
                       ###Rapportjaar###
                       fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Gerelateerde documenten###
+                      fields:3b05127d-d3ec-46c5-8e58-664334eed2d3,
 
                       ###Links-naar-documenten###
                       fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
@@ -31,7 +34,7 @@ fieldGroups:40fa78b5-4e89-47c0-99cb-a8e936a09d19 a form:FieldGroup ;
 
                       ### RemoteDataObject/url ###
                       fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db,
-                      
+
                       ###Info Upload (CUSTOM)###
                       fields:4ee01de8-46b2-4109-84cf-d60bebaeb10e.
 

--- a/formSkeleton/inputFields/input-fields.ttl
+++ b/formSkeleton/inputFields/input-fields.ttl
@@ -1869,3 +1869,15 @@ fields:788b9a98-684e-4d20-ae22-0ae610e6b494-refers_to a form:Field ;
     sh:order 1001 ;
     sh:path (<http://data.europa.eu/eli/ontology#has_part> <http://data.europa.eu/eli/ontology#refers_to>);
     sh:group fields:aDynamicPropertyGroup .
+
+fields:3b05127d-d3ec-46c5-8e58-664334eed2d3 a form:Field ;
+    sh:name "Gerelateerde documenten" ;
+    sh:order 103 ;
+    sh:path dct:relation ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:resultMessage "Dit veld is verplicht." ;
+        sh:path dct:relation ] ;
+    form:displayType displayTypes:decisionDocuments ;
+    sh:group fields:aDynamicPropertyGroup .


### PR DESCRIPTION
This field allows CKB users to reference submitted documents of EBs they govern.