### PR TITLE
Add kerkenbeleidsplan eredienstbesturen form

### DIFF
--- a/formSkeleton/forms/Kerkenbeleidsplan-eredienstbesturen/form.ttl
+++ b/formSkeleton/forms/Kerkenbeleidsplan-eredienstbesturen/form.ttl
@@ -1,0 +1,92 @@
+##########################################################
+# Alert for "Kerkenbeleidsplan eredienstbesturen"
+##########################################################
+fields:90f379f7-8f37-46b4-a616-e2d273dd2a02 a form:Field;
+    mu:uuid "90f379f7-8f37-46b4-a616-e2d273dd2a02" ;
+    sh:name "Met dit formulier dien je een kerkenbeleidsplan in voor de rooms-katholieke parochiekerken op het grondgebied van je gemeente.";
+    sh:order 101;
+    form:options """{ "skin": "warning", "icon": "alert-triangle", "size": "small", "closable": false }""";
+    form:displayType displayTypes:alert ;
+    sh:group fields:aDynamicPropertyGroup .
+
+##########################################################
+# Type Kerkenbeleidsplan
+##########################################################
+fields:7e11fe8a-ce14-4e31-9bc9-d75a79a69c47 a form:Field ;
+    mu:uuid "7e11fe8a-ce14-4e31-9bc9-d75a79a69c47" ;
+    sh:name "Type kerkenbeleidsplan" ;
+    sh:path lblodBesluit:TypeKerkenbeleidsplan ;
+    form:validations
+      [ a form:RequiredConstraint ;
+        form:grouping form:Bag ;
+        sh:path lblodBesluit:TypeKerkenbeleidsplan ;
+        sh:resultMessage "Dit veld is verplicht."@nl
+      ];
+    form:options  """{"conceptScheme":"http://lblod.data.gift/concept-schemes/c7d95519-9ef1-402b-b824-56ec3b1a0f61"}""" ;
+    form:help "Voeg ook het volledige plan toe in de bijlagen bij selectie van een (her)bevestiging of actualisatie van het kerkenbeleidsplan.";
+    form:displayType displayTypes:conceptSchemeSelector ;
+    sh:group fields:aDynamicPropertyGroup.
+
+##########################################################
+# File upload with custom help text
+##########################################################
+fields:0acbcaf3-db99-4c9c-82ca-2b957530a53a a form:Field ;
+    mu:uuid "0acbcaf3-db99-4c9c-82ca-2b957530a53a" ;
+    sh:name "Bestanden" ;
+    sh:path dct:hasPart;
+    form:validations
+     [ a  form:RequiredConstraint ;
+          form:grouping form:Bag ;
+          sh:path dct:hasPart;
+          sh:resultMessage "Gelieve minstens één URL of bestand op te geven."@nl # TODO: later custom validator
+     ];
+      form:displayType displayTypes:files; # consider this v1.0
+      form:help """Laad hier het volledige kerkenbeleidsplan op, zoals verplicht door het artikel 33/2. Geef elke bestandsnaam dezelfde structuur: 'naam gemeente_KBP_jaartal'. Schrijf bijvoorbeeld 'Aalst_KBP_2025.pdf' en voor eventuele bijlagen 'Aalst_KBP_2025_bijlage1'.""" ;
+    sh:group fields:aDynamicPropertyGroup .
+
+###########Kerkenbeleidsplan eredienstbesturen###########
+
+fieldGroups:b64f58c6-60a4-4dcc-ab13-636b751db9f7 a form:FieldGroup ;
+    mu:uuid "b64f58c6-60a4-4dcc-ab13-636b751db9f7" ;
+    form:hasField
+                      ###Alert (custom)###
+                      fields:90f379f7-8f37-46b4-a616-e2d273dd2a02,
+
+                      ###Welk-beslissingsorgaan-nam-het-besluit?###
+                      fields:4c7820f0-4011-4ab4-a16a-e128800e11bc,
+
+                      ###Datum-zitting/besluit###
+                      fields:3dd6ed93-40f7-4d70-a6cb-f4de53dc8bfb,
+
+                      ###Type-kerkenbeleidsplan###
+                      fields:7e11fe8a-ce14-4e31-9bc9-d75a79a69c47,
+
+                      ###Rapportjaar###
+                      fields:41737f90-02d6-4036-8d60-5d5b6ccf939c,
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:0acbcaf3-db99-4c9c-82ca-2b957530a53a,
+
+                      ###Type RemoteDataObject or FileDataObject###
+                      fields:355fe001-cdca-48cc-8a6e-88b3aab09874,
+
+                      ### RemoteDataObject/url ###
+                      fields:d0052f0d-90bc-4543-a6b0-e90a1c1117db.
+
+
+fields:0827fafe-ad19-49e1-8b2e-105d2c08a54a form:hasConditionalFieldGroup fields:894b98d5-6e83-4c8a-9afd-1385863286f6.
+
+fields:894b98d5-6e83-4c8a-9afd-1385863286f6 a form:ConditionalFieldGroup ;
+    mu:uuid "894b98d5-6e83-4c8a-9afd-1385863286f6";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/48c3290d-d9e3-4a38-b14e-e7c417e3a13a>
+      ] ;
+    form:hasFieldGroup fieldGroups:b64f58c6-60a4-4dcc-ab13-636b751db9f7 .
+


### PR DESCRIPTION
## ID
DL-6235

## Description

Add kerkenbeleidsplan eredienstbesturen form, needs https://github.com/lblod/enrich-submission-service/pull/26 to test form. Use `wolfderechter/enrich-submission-service:latest` or build from PR 

See https://github.com/lblod/app-digitaal-loket/pull/615

## Related PR's

- https://github.com/lblod/enrich-submission-service/pull/26