### PR TITLE
Fix missing classification type

### DIFF
--- a/formSkeleton/forms/Besluitenlijst/algemene-vergadering-opdrachthoudende-vereniging-met-private-deelname/form.ttl
+++ b/formSkeleton/forms/Besluitenlijst/algemene-vergadering-opdrachthoudende-vereniging-met-private-deelname/form.ttl
@@ -1,0 +1,35 @@
+fieldGroups:0e5b659c-b807-463a-bf89-6335072edcc8 a form:FieldGroup ;
+    mu:uuid "0e5b659c-b807-463a-bf89-6335072edcc8" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:d58ffe8e-3742-4fde-aca1-41b849bb4749.
+
+fields:d58ffe8e-3742-4fde-aca1-41b849bb4749 a form:ConditionalFieldGroup ;
+    mu:uuid "d58ffe8e-3742-4fde-aca1-41b849bb4749";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitDocumentType/3fa67785-ffdc-4b30-8880-2b99d97b4dee>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> # Opdrachthoudende vereniging met private deelname
+      ] ;
+    form:hasFieldGroup fieldGroups:0e5b659c-b807-463a-bf89-6335072edcc8 .

--- a/formSkeleton/forms/Rechtspositieregeling-(RPR)/algemene-vergadering-opdrachthoudende-vereniging-met-private-deelname/form.ttl
+++ b/formSkeleton/forms/Rechtspositieregeling-(RPR)/algemene-vergadering-opdrachthoudende-vereniging-met-private-deelname/form.ttl
@@ -1,0 +1,35 @@
+fieldGroups:ecbae079-8b9b-415a-8e1e-010da362bb0e a form:FieldGroup ;
+    mu:uuid "ecbae079-8b9b-415a-8e1e-010da362bb0e" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:a20a4a8e-04ee-4159-821e-a144ff6a7e8f.
+
+fields:a20a4a8e-04ee-4159-821e-a144ff6a7e8f a form:ConditionalFieldGroup ;
+    mu:uuid "a20a4a8e-04ee-4159-821e-a144ff6a7e8f";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> # Opdrachthoudende vereniging met private deelname
+      ] ;
+    form:hasFieldGroup fieldGroups:ecbae079-8b9b-415a-8e1e-010da362bb0e .

--- a/formSkeleton/forms/Rechtspositieregeling-(RPR)/raad-van-bestuur-opdrachthoudende-vereniging-met-private-deelname/form.ttl
+++ b/formSkeleton/forms/Rechtspositieregeling-(RPR)/raad-van-bestuur-opdrachthoudende-vereniging-met-private-deelname/form.ttl
@@ -1,0 +1,35 @@
+fieldGroups:bc7a6263-c7fd-4bca-8716-073b40c2dea2 a form:FieldGroup ;
+    mu:uuid "bc7a6263-c7fd-4bca-8716-073b40c2dea2" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:1e0f541f-61e9-43a7-bc5f-612eb44f52bb,
+
+                      ###Bestanden###
+                      fields:c7c5a589-0785-4032-a4bd-ee589add3c39.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:6cc51392-1c52-419c-8c61-394539a9ef86.
+
+fields:6cc51392-1c52-419c-8c61-394539a9ef86 a form:ConditionalFieldGroup ;
+    mu:uuid "6cc51392-1c52-419c-8c61-394539a9ef86";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/fb21d14b-734b-48f4-bd4e-888163fd08e8>
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> # Opdrachthoudende vereniging met private deelname
+      ] ;
+    form:hasFieldGroup fieldGroups:bc7a6263-c7fd-4bca-8716-073b40c2dea2 .

--- a/formSkeleton/forms/Toetreding-rechtspersoon/algemene-vergadering-opdrachthoudende-vereniging-met-private-deelname/form.ttl
+++ b/formSkeleton/forms/Toetreding-rechtspersoon/algemene-vergadering-opdrachthoudende-vereniging-met-private-deelname/form.ttl
@@ -1,0 +1,35 @@
+fieldGroups:d873f0e7-5b77-4fa3-bc7d-0d778dbb9db1 a form:FieldGroup ;
+    mu:uuid "d873f0e7-5b77-4fa3-bc7d-0d778dbb9db1" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:f58dbbb1-16a3-4961-84a2-52dba7207186.
+
+fields:f58dbbb1-16a3-4961-84a2-52dba7207186 a form:ConditionalFieldGroup ;
+    mu:uuid "f58dbbb1-16a3-4961-84a2-52dba7207186";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> # Opdrachthoudende vereniging met private deelname
+      ] ;
+    form:hasFieldGroup fieldGroups:d873f0e7-5b77-4fa3-bc7d-0d778dbb9db1 .

--- a/formSkeleton/forms/Toetreding-rechtspersoon/raad-van-bestuur-opdrachthoudende-vereniging-met-private-deelname/form.ttl
+++ b/formSkeleton/forms/Toetreding-rechtspersoon/raad-van-bestuur-opdrachthoudende-vereniging-met-private-deelname/form.ttl
@@ -1,0 +1,35 @@
+fieldGroups:6cf4d1cb-2f3f-4537-892c-7c2c825e0078 a form:FieldGroup ;
+    mu:uuid "6cf4d1cb-2f3f-4537-892c-7c2c825e0078" ;
+    form:hasField
+
+                      ###Links-naar-documenten###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95b,
+
+                      ###Bestanden###
+                      fields:c955d641-b9b3-4ec7-9838-c2a477c7e95a.
+
+# this field is the custom bestuursorgaan selector
+fields:4c7820f0-4011-4ab4-a16a-e128800e11bc form:hasConditionalFieldGroup fields:7aaa2f5b-2e3c-4c92-8acd-bdec0c43fe20.
+
+fields:7aaa2f5b-2e3c-4c92-8acd-bdec0c43fe20 a form:ConditionalFieldGroup ;
+    mu:uuid "7aaa2f5b-2e3c-4c92-8acd-bdec0c43fe20";
+    form:conditions
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path rdf:type ;
+        form:conceptScheme <http://lblod.data.gift/concept-schemes/71e6455e-1204-46a6-abf4-87319f58eaa5> ;
+        form:customValue <https://data.vlaanderen.be/id/concept/BesluitType/e27ef237-29de-49b8-be22-4ee2ab2d4e5b> # Toetreding rechtspersoon
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+      ],
+      [ a form:SingleCodelistValue ;
+        form:grouping form:Bag ;
+        sh:path ( eli:passed_by mandaat:isTijdspecialisatieVan besluit:bestuurt besluit:classificatie ) ;
+        form:conceptScheme <http://data.vlaanderen.be/id/conceptscheme/BestuurseenheidClassificatieCode> ;
+        form:customValue <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> # Opdrachthoudende vereniging met private deelname
+      ] ;
+    form:hasFieldGroup fieldGroups:6cf4d1cb-2f3f-4537-892c-7c2c825e0078 .


### PR DESCRIPTION
## Ticket ID

DL-6447

## Ticket Description

`Opdrachthoudende vereniging met private deelname` organizations cannot see URL/Document Upload sections at the moment as the forms have not been updated. This PR adds the new classification type to those forms.